### PR TITLE
Fix WC_REST_Posts_Controller::prepare_links call

### DIFF
--- a/inc/api/customers.php
+++ b/inc/api/customers.php
@@ -505,7 +505,7 @@ class Metorik_Helper_API_Customers extends WC_REST_Posts_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $customer ) );
+		$response->add_links( $this->prepare_links( $customer, $request ) );
 
 		/**
 		 * Filter customer data returned from the REST API.


### PR DESCRIPTION
WC_REST_Posts_Controller::prepare_links expects 2 parameters; in `Metorik_Helper_API_Customers::prepare_item_for_response` we're only passing one.

This fixes compatibility issues with PHP 7.2.