### PR TITLE
v2.0.9

### DIFF
--- a/inc/cart-recovery.php
+++ b/inc/cart-recovery.php
@@ -222,7 +222,7 @@ class Metorik_Cart_Recovery {
 
 			foreach ( $cart as $key => $cart_item ) {
 				// set the product data for each cart item
-				if ( ! isset( $cart_item['data'] ) ) {
+				if ( empty( $cart_item['data'] ) || ! is_callable([$cart_item['data'],'get_price']) ) {
 					$variationOrProductId = !empty( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : $cart_item['product_id'];
 					if (!empty($variationOrProductId)) {
 						$product = wc_get_product( $variationOrProductId );
@@ -232,8 +232,9 @@ class Metorik_Cart_Recovery {
 					}
 				}
 
-				// if we can't get the cart item data, we have to remove it to avoid errors
-				if (empty($cart_item['data'])) {
+				// if we can't get the cart item data or if it has no price
+				// remove it, otherwise we hit errors later
+				if (empty($cart_item['data']) || ! is_callable([$cart_item['data'],'get_price'])) {
 					unset($cart[ $key ]);
 					continue;
 				}

--- a/inc/cart-recovery.php
+++ b/inc/cart-recovery.php
@@ -232,6 +232,12 @@ class Metorik_Cart_Recovery {
 					}
 				}
 
+				// if we can't get the cart item data, we have to remove it to avoid errors
+				if (empty($cart_item['data'])) {
+					unset($cart[ $key ]);
+					continue;
+				}
+
 				// set the variation to an empty array if it doesn't exist
 				// this is workaround for a php notice that can occur later when Woo pulls the cart
 				if ( ! isset( $cart_item['variation'] ) ) {

--- a/metorik-helper.php
+++ b/metorik-helper.php
@@ -50,6 +50,7 @@ class Metorik_Helper {
 	 */
 	public function __construct() {
 		add_action( 'plugins_loaded', [ $this, 'init' ] );
+		add_action( 'init', [ $this, 'load_text_domain' ] );
 
 		// Set URL
 		$this->url = plugin_dir_url( __FILE__ );
@@ -60,8 +61,8 @@ class Metorik_Helper {
 	 */
 	public function init() {
 		if ( class_exists( 'WooCommerce' ) ) {
-			// Woo HPOS compatibility
 			add_action( 'before_woocommerce_init', function () {
+				// Woo HPOS compatibility
 				if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 					\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 				}
@@ -90,8 +91,9 @@ class Metorik_Helper {
 		} else {
 			add_action( 'admin_notices', [ $this, 'no_wc' ] );
 		}
+	}
 
-		// Plugin textdomain
+	public function load_text_domain() {
 		load_plugin_textdomain( 'metorik', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 	}
 

--- a/metorik-helper.php
+++ b/metorik-helper.php
@@ -4,12 +4,12 @@
  * Plugin Name: Metorik Helper
  * Plugin URI: https://metorik.com
  * Description: Reports, integrations, automatic emails, and cart tracking for WooCommerce stores.
- * Version: 2.0.9-beta1
+ * Version: 2.0.9
  * Author: Metorik
  * Author URI: https://metorik.com
  * Text Domain: metorik
  * WC requires at least: 4.0.0
- * WC tested up to: 9.4.2
+ * WC tested up to: 9.4.3
  * Requires Plugins: woocommerce
  * Requires at least: 5.0
  * Requires PHP: 7.4
@@ -18,7 +18,7 @@ class Metorik_Helper {
 	/**
 	 * Current version of Metorik.
 	 */
-	public $version = '2.0.9-beta1';
+	public $version = '2.0.9';
 
 	/**
 	 * URL dir for plugin.

--- a/metorik-helper.php
+++ b/metorik-helper.php
@@ -9,7 +9,7 @@
  * Author URI: https://metorik.com
  * Text Domain: metorik
  * WC requires at least: 4.0.0
- * WC tested up to: 9.4.3
+ * WC tested up to: 9.5.1
  * Requires Plugins: woocommerce
  * Requires at least: 5.0
  * Requires PHP: 7.4

--- a/metorik-helper.php
+++ b/metorik-helper.php
@@ -4,12 +4,12 @@
  * Plugin Name: Metorik Helper
  * Plugin URI: https://metorik.com
  * Description: Reports, integrations, automatic emails, and cart tracking for WooCommerce stores.
- * Version: 2.0.8
+ * Version: 2.0.9-beta1
  * Author: Metorik
  * Author URI: https://metorik.com
  * Text Domain: metorik
  * WC requires at least: 4.0.0
- * WC tested up to: 9.3.3
+ * WC tested up to: 9.4.2
  * Requires Plugins: woocommerce
  * Requires at least: 5.0
  * Requires PHP: 7.4
@@ -18,7 +18,7 @@ class Metorik_Helper {
 	/**
 	 * Current version of Metorik.
 	 */
-	public $version = '2.0.8';
+	public $version = '2.0.9-beta1';
 
 	/**
 	 * URL dir for plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, woocommerce reports, woocommerce emails, woocommerce carts, w
 Requires at least: 5.0
 Requires PHP: 7.4
 Tested up to: 6.7.1
-Stable tag: 2.0.8
+Stable tag: 2.0.9
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/readme.txt
+++ b/readme.txt
@@ -143,6 +143,7 @@ To get them back, go to http://yoursite.com/wp-admin?show-metorik-notices=yes wh
 == Changelog ==
 = 2.0.9 =
 * Bug fix for cart recovery when the cart contains an invalid product.
+* Update plugin translation loading hook to `init` as per WP 6.7+ guidelines.
 
 = 2.0.8 =
 * Bug fix for cart recovery when the cart has a coupon attached.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bryceadams, jkudish, metorik
 Tags: woocommerce, woocommerce reports, woocommerce emails, woocommerce carts, woocommerce export
 Requires at least: 5.0
 Requires PHP: 7.4
-Tested up to: 6.7.0
+Tested up to: 6.7.1
 Stable tag: 2.0.8
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -141,6 +141,9 @@ To hide the links from individual orders/products, you can click the 'Screen Opt
 To get them back, go to http://yoursite.com/wp-admin?show-metorik-notices=yes while logged in as an administrator.
 
 == Changelog ==
+= 2.0.9 =
+* Bug fix for cart recovery when the cart contains an invalid product.
+
 = 2.0.8 =
 * Bug fix for cart recovery when the cart has a coupon attached.
 


### PR DESCRIPTION
- Bug fix for cart recovery when the cart contains an invalid product.
- Update plugin translation loading hook to `init` as per WP 6.7+ guidelines.
- Version bumps